### PR TITLE
feat: rename `cgr30p.parse_dict` to `cgr30p.parse_csv_row`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2025-10-04
+
+### Breaking change
+- Rename `cgr30p.parse_dict` to `cgr30p.parse_csv_row`
+
+
 ## [0.3.0] - 2025-10-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aerotrace-parsers"
-version = "0.3.0"
+version = "0.4.0"
 description = "Aircraft Engine Monitoring System (EMS) data parsers for real-time telemetry processing"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/aerotrace/parsers/cgr30p.py
+++ b/src/aerotrace/parsers/cgr30p.py
@@ -16,7 +16,7 @@ Example usage:
     >>>
     >>> # Parse individual row (if you have CSV data already loaded)
     >>> row_dict = {'RPMLEFT': '2400', 'RPMRIGHT': '2380', 'SEL TANK QTY': 'TOTAL   : 45.2'}
-    >>> engine_data = cgr30p.parse_dict(row_dict)
+    >>> engine_data = cgr30p.parse_csv_row(row_dict)
     >>> print(f"Left RPM: {engine_data.rpm.left}")
 """
 
@@ -35,7 +35,7 @@ DATA_START_LINE = 15
 logger = logging.getLogger(__name__)
 
 # Public API
-__all__ = ["parse_file", "parse_dict"]
+__all__ = ["parse_file", "parse_csv_row"]
 
 
 def _get_float(data: Dict[str, str], key: str) -> Optional[float]:
@@ -126,7 +126,7 @@ def _parse_cylinders(
     return engine.Cylinders(readings)
 
 
-def parse_dict(data: Dict[str, str]) -> engine.EngineData:
+def parse_csv_row(data: Dict[str, str]) -> engine.EngineData:
     """Parse a single row of CGR-30P data from a dictionary
 
     Args:
@@ -194,7 +194,7 @@ def parse_file(file_path: Union[str, Path]) -> Iterator[engine.EngineData]:
 
         for row_num, row in enumerate(reader, start=DATA_START_LINE):
             try:
-                engine_data = parse_dict(row)
+                engine_data = parse_csv_row(row)
                 yield engine_data
             except Exception as e:
                 logger.warning("Error parsing row %d: %s", row_num, e)


### PR DESCRIPTION
It was confusing with the recent `EngineData.to_dict` as it felt like you could pass the return value of htat into `parse_dict`, which was incorrect